### PR TITLE
Use psk_key instead of psk_id

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -368,7 +368,8 @@ pub const Suite = struct {
         try key_schedule_ctx.append(@enumToInt(mode));
         try key_schedule_ctx.appendSlice(psk_id_hash.constSlice());
         try key_schedule_ctx.appendSlice(info_hash.constSlice());
-        var secret = try suite.labeledExtract(&suite.id.context, dh_secret, "secret", psk_id);
+        const psk_key: []const u8 = if (psk) |p| p.key else &[_]u8{};
+        var secret = try suite.labeledExtract(&suite.id.context, dh_secret, "secret", psk_key);
         var exporter_secret = try BoundedArray(u8, max_prk_length).init(suite.kdf.prk_length);
         try suite.labeledExpand(exporter_secret.slice(), &suite.id.context, secret, "exp", key_schedule_ctx.items);
 


### PR DESCRIPTION
Fixed to use psk key instead of psk_id when using secret in the KeySchedule function.

## reference

https://www.rfc-editor.org/rfc/rfc9180.html#section-5.1

```
def KeySchedule<ROLE>(mode, shared_secret, info, psk, psk_id):
  VerifyPSKInputs(mode, psk, psk_id)

  psk_id_hash = LabeledExtract("", "psk_id_hash", psk_id)
  info_hash = LabeledExtract("", "info_hash", info)
  key_schedule_context = concat(mode, psk_id_hash, info_hash)

  // psk_key is used instead of psk_id
  secret = LabeledExtract(shared_secret, "secret", psk)
 ```