### PR TITLE
Add publicKeyLength() and secretKeyLength() helpers

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -303,6 +303,14 @@ pub const Hpke = struct {
         return .{ .suite = CipherSuite.init(suite_id) };
     }
 
+    pub fn publicKeyLength(self: *const Hpke) u16 {
+        return self.suite.public_key_length;
+    }
+
+    pub fn secretKeyLength(self: *const Hpke) u16 {
+        return self.suite.secret_key_length;
+    }
+
     pub fn senderSetup(self: *const Hpke, pk_r: []const u8, info: []const u8, io: std.Io) SetupError!SenderResult {
         return self.senderSetupCore(pk_r, info, .base, "", "", null, io);
     }


### PR DESCRIPTION
Expose the public and secret key lengths for the current cipher suite. This allows users to slice the arrays returned by deriveKeyPair without hard-coding lengths, making user code uniform across different KEMs.

Example usage:
```
const h = hpke.Hpke.init(.x25519_hkdf_sha256_aes128_gcm); const kp_r = h.deriveKeyPair(&seed);
const pk_r = kp_r.pk[0..h.publicKeyLength()];
const sk_r = kp_r.sk[0..h.secretKeyLength()];
```